### PR TITLE
refactor: refactor screenshot capture and logging handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           pip install pytest
           pip install pytest-cov
           pip install pytest-xdist
-          pip install pytest-asyncio==0.38.0
+          pip install pytest-asyncio==0.23.8
           pip install genbadge[all]
 
       - name: List dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           pip install pytest
           pip install pytest-cov
           pip install pytest-xdist
-          pip install pytest-asyncio
+          pip install pytest-asyncio==0.38.0
           pip install genbadge[all]
 
       - name: List dependencies

--- a/main.py
+++ b/main.py
@@ -20,10 +20,8 @@ logfire.configure(
     token=None,
     project_name="auto-click",
     service_name=f"{getpass.getuser()}",
-    trace_sample_rate=1.0,
     show_summary=True,
     data_dir=".logfire",
-    fast_shutdown=True,
     console={
         "colors": "auto",
         "span_style": "show-parents",

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import time
 from typing import Union
-import getpass
 import secrets
 
 import yaml

--- a/main.py
+++ b/main.py
@@ -66,7 +66,6 @@ class RemoteContoller(ConfigModel):
             try:
                 device_details = self.get_screenshot()
                 for config_dict in self.image_list:
-                    # logfire.info("Checking Image", **config_dict.model_dump())
                     button_center_x, button_center_y = ImageComparison(
                         image_cfg=config_dict, screenshot=device_details.screenshot
                     ).find()

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ class RemoteContoller(ConfigModel):
                         )
                         time.sleep(config_dict.delay_after_click)
             except Exception as e:
-                logfire.error("Error in getting device:", error=e)
+                logfire.error("Error in getting device:", error=e, _exc_info=True)
                 _random_interval = secrets.randbelow(self.random_interval)
                 logfire.info("Retrying...", retry_interval=_random_interval)
                 time.sleep(_random_interval)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import time
+from typing import Union
 import getpass
 import secrets
 
@@ -50,7 +51,7 @@ class RemoteContoller(ConfigModel):
 
     def click_button(
         self,
-        device: Page | AdbDevice | ShiftPosition,
+        device: Union[Page, AdbDevice, ShiftPosition],
         calibrated_x: int,
         calibrated_y: int,
         click_this: bool,
@@ -86,14 +87,13 @@ class RemoteContoller(ConfigModel):
                         calibrated_x, calibrated_y = device_details.calibrate(
                             button_center_x=button_center_x, button_center_y=button_center_y
                         )
-                        if calibrated_x and calibrated_y:
-                            self.click_button(
-                                device=device_details.device,
-                                calibrated_x=calibrated_x,
-                                calibrated_y=calibrated_y,
-                                click_this=config_dict.click_this,
-                            )
-                            time.sleep(config_dict.delay_after_click)
+                        self.click_button(
+                            device=device_details.device,
+                            calibrated_x=calibrated_x,
+                            calibrated_y=calibrated_y,
+                            click_this=config_dict.click_this,
+                        )
+                        time.sleep(config_dict.delay_after_click)
             except Exception as e:
                 logfire.error("Error in getting device:", error=e, _exc_info=True)
                 _random_interval = secrets.randbelow(self.random_interval)

--- a/main.py
+++ b/main.py
@@ -49,17 +49,28 @@ class RemoteContoller(ConfigModel):
         return GetScreen.from_exist_window(window_title=self.target)
 
     def click_button(
-        self, device: Page | AdbDevice | ShiftPosition, button_center_x: int, button_center_y: int
+        self,
+        device: Page | AdbDevice | ShiftPosition,
+        calibrated_x: int,
+        calibrated_y: int,
+        click_this: bool,
     ) -> None:
-        if isinstance(device, Page):
-            device.mouse.click(x=button_center_x, y=button_center_y)
-        elif isinstance(device, AdbDevice):
-            device.click(x=button_center_x, y=button_center_y)
+        if self.auto_click and click_this:
+            if isinstance(device, Page):
+                device.mouse.click(x=calibrated_x, y=calibrated_y)
+            if isinstance(device, AdbDevice):
+                device.click(x=calibrated_x, y=calibrated_y)
+            if isinstance(device, ShiftPosition):
+                pyautogui.moveTo(x=calibrated_x, y=calibrated_y)
+                pyautogui.click()
         else:
-            pyautogui.moveTo(
-                x=button_center_x + device.shift_x, y=button_center_y + device.shift_y
+            logfire.info(
+                "Button found but click feature is disabled",
+                x=calibrated_x,
+                y=calibrated_y,
+                auto_click=self.auto_click,
+                click_this=click_this,
             )
-            pyautogui.click()
 
     def main(self) -> None:
         while True:
@@ -67,20 +78,22 @@ class RemoteContoller(ConfigModel):
                 device_details = self.get_screenshot()
                 for config_dict in self.image_list:
                     button_center_x, button_center_y = ImageComparison(
-                        image_cfg=config_dict, screenshot=device_details.screenshot
+                        image_cfg=config_dict,
+                        screenshot=device_details.screenshot,
+                        device=device_details.device,
                     ).find()
-                    if (
-                        button_center_x
-                        and button_center_y
-                        and self.auto_click is True
-                        and config_dict.click_this is True
-                    ):
-                        self.click_button(
-                            device=device_details.device,
-                            button_center_x=button_center_x,
-                            button_center_y=button_center_y,
+                    if button_center_x and button_center_y:
+                        calibrated_x, calibrated_y = device_details.calibrate(
+                            button_center_x=button_center_x, button_center_y=button_center_y
                         )
-                        time.sleep(config_dict.delay_after_click)
+                        if calibrated_x and calibrated_y:
+                            self.click_button(
+                                device=device_details.device,
+                                calibrated_x=calibrated_x,
+                                calibrated_y=calibrated_y,
+                                click_this=config_dict.click_this,
+                            )
+                            time.sleep(config_dict.delay_after_click)
             except Exception as e:
                 logfire.error("Error in getting device:", error=e, _exc_info=True)
                 _random_interval = secrets.randbelow(self.random_interval)

--- a/main.py
+++ b/main.py
@@ -15,20 +15,7 @@ from playwright.sync_api import Page
 from src.utils.get_serial import ADBDeviceManager
 from src.types.output_models import Screenshot, ShiftPosition
 
-logfire.configure(
-    send_to_logfire=False,
-    token=None,
-    project_name="auto-click",
-    service_name=f"{getpass.getuser()}",
-    show_summary=True,
-    data_dir=".logfire",
-    console={
-        "colors": "auto",
-        "span_style": "show-parents",
-        "verbose": True,
-        "min_log_level": "info",
-    },
-)
+logfire.configure(send_to_logfire=False)
 
 
 class RemoteContoller(ConfigModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "pyyaml>=6.0.2",
 ]
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.9"
 
 [project.urls]
 Homepage = "https://github.com/Mai0313/auto_click"
@@ -193,8 +193,8 @@ extend-include = ["**/*.ipynb", "*.sh"]
 # Allow imports relative to the "src" and "test" directories.
 src = ["src", "tests"]
 
-# Assume Python 3.10.*
-target-version = "py310"
+# Assume Python 3.9.*
+target-version = "py39"
 
 # Set the cache directory to `logs/ruff_cache`.
 cache-dir = "./.cache/ruff"  # default: ".ruff_cache", now it is not allowed to create cache dir in logs
@@ -433,7 +433,7 @@ ignore-words-list = ["longe"]
 [tool.mypy]
 plugins = ["pydantic.mypy"]
 # strict = true
-python_version = "3.10"
+python_version = "3.9"
 explicit_package_bases = true
 cache_dir = "./.cache/.mypy_cache"
 exclude = ["^src/ameba/*", "^src/tma_server/*", "^tests/"]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -46,7 +46,7 @@ comm==0.2.2
     # via ipywidgets
 coverage==7.6.1
     # via pytest-cov
-debugpy==1.8.5
+debugpy==1.8.6
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -69,7 +69,7 @@ execnet==2.1.1
 executing==2.1.0
     # via logfire
     # via stack-data
-filelock==3.15.4
+filelock==3.16.1
     # via virtualenv
 flake8==7.1.1
     # via flake8-html
@@ -80,16 +80,19 @@ googleapis-common-protos==1.65.0
     # via opentelemetry-exporter-otlp-proto-http
 greenlet==3.0.3
     # via playwright
-identify==2.6.0
+identify==2.6.1
     # via pre-commit
-idna==3.8
+idna==3.10
     # via requests
 importlib-metadata==8.4.0
+    # via jupyter-client
     # via opentelemetry-api
+    # via pyinstaller
+    # via pyinstaller-hooks-contrib
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
-ipython==8.27.0
+ipython==8.18.1
     # via ipykernel
     # via ipywidgets
 ipywidgets==8.1.5
@@ -97,14 +100,14 @@ jedi==0.19.1
     # via ipython
 jinja2==3.1.4
     # via flake8-html
-jupyter-client==8.6.2
+jupyter-client==8.6.3
     # via ipykernel
 jupyter-core==5.7.2
     # via ipykernel
     # via jupyter-client
 jupyterlab-widgets==3.0.13
     # via ipywidgets
-logfire==0.52.0
+logfire==0.55.0
     # via auto-click
 macholib==1.16.3 ; sys_platform == 'darwin'
     # via pyinstaller
@@ -125,7 +128,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.1.1
+numpy==2.0.2
     # via opencv-python
 opencv-python==4.10.0.84
     # via auto-click
@@ -158,30 +161,30 @@ parso==0.8.4
     # via jedi
 pefile==2024.8.26 ; sys_platform == 'win32'
     # via pyinstaller
-pexpect==4.9.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
+pexpect==4.9.0 ; sys_platform != 'win32'
     # via ipython
 pillow==10.4.0
     # via adbutils
     # via auto-click
     # via genbadge
     # via pyscreeze
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via jupyter-core
     # via virtualenv
-playwright==1.46.0
+playwright==1.47.0
     # via auto-click
 pluggy==1.5.0
     # via pytest
 pre-commit==3.8.0
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==4.25.4
+protobuf==4.25.5
     # via googleapis-common-protos
     # via logfire
     # via opentelemetry-proto
 psutil==6.0.0
     # via ipykernel
-ptyprocess==0.7.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
+ptyprocess==0.7.0 ; sys_platform != 'win32'
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
@@ -193,11 +196,11 @@ pycodestyle==2.12.1
     # via flake8
 pycparser==2.22 ; implementation_name == 'pypy'
     # via cffi
-pydantic==2.9.0
+pydantic==2.9.2
     # via auto-click
-pydantic-core==2.23.2
+pydantic-core==2.23.4
     # via pydantic
-pyee==11.1.0
+pyee==12.0.0
     # via playwright
 pyelftools==0.31
     # via apkutils2
@@ -232,7 +235,7 @@ pyrootutils==1.0.4
     # via autorootcwd
 pyscreeze==1.0.1
     # via pyautogui
-pytest==8.3.2
+pytest==8.3.3
     # via pytest-asyncio
     # via pytest-cov
     # via pytest-xdist
@@ -266,13 +269,13 @@ requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
 retry==0.9.2
     # via adbutils
-rich==13.8.0
+rich==13.8.1
     # via logfire
 rootutils==1.0.7
     # via auto-click
 rubicon-objc==0.4.9 ; platform_system == 'Darwin'
     # via mouseinfo
-setuptools==74.1.2
+setuptools==75.1.0
     # via genbadge
     # via opentelemetry-instrumentation
     # via pyinstaller
@@ -305,11 +308,9 @@ typing-extensions==4.12.2
     # via pydantic
     # via pydantic-core
     # via pyee
-tzdata==2024.1
-    # via pydantic
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests
-virtualenv==20.26.3
+virtualenv==20.26.6
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -320,5 +321,5 @@ wrapt==1.16.0
     # via opentelemetry-instrumentation
 xmltodict==0.13.0
     # via apkutils2
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -41,11 +41,13 @@ googleapis-common-protos==1.65.0
     # via opentelemetry-exporter-otlp-proto-http
 greenlet==3.0.3
     # via playwright
-idna==3.8
+idna==3.10
     # via requests
 importlib-metadata==8.4.0
     # via opentelemetry-api
-logfire==0.52.0
+    # via pyinstaller
+    # via pyinstaller-hooks-contrib
+logfire==0.55.0
     # via auto-click
 macholib==1.16.3 ; sys_platform == 'darwin'
     # via pyinstaller
@@ -55,7 +57,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mouseinfo==0.1.3
     # via pyautogui
-numpy==2.1.1
+numpy==2.0.2
     # via opencv-python
 opencv-python==4.10.0.84
     # via auto-click
@@ -88,9 +90,9 @@ pillow==10.4.0
     # via adbutils
     # via auto-click
     # via pyscreeze
-playwright==1.46.0
+playwright==1.47.0
     # via auto-click
-protobuf==4.25.4
+protobuf==4.25.5
     # via googleapis-common-protos
     # via logfire
     # via opentelemetry-proto
@@ -98,11 +100,11 @@ py==1.11.0
     # via retry
 pyautogui==0.9.54
     # via auto-click
-pydantic==2.9.0
+pydantic==2.9.2
     # via auto-click
-pydantic-core==2.23.2
+pydantic-core==2.23.4
     # via pydantic
-pyee==11.1.0
+pyee==12.0.0
     # via playwright
 pyelftools==0.31
     # via apkutils2
@@ -151,13 +153,13 @@ requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
 retry==0.9.2
     # via adbutils
-rich==13.8.0
+rich==13.8.1
     # via logfire
 rootutils==1.0.7
     # via auto-click
 rubicon-objc==0.4.9 ; platform_system == 'Darwin'
     # via mouseinfo
-setuptools==74.1.2
+setuptools==75.1.0
     # via opentelemetry-instrumentation
     # via pyinstaller
     # via pyinstaller-hooks-contrib
@@ -170,14 +172,12 @@ typing-extensions==4.12.2
     # via pydantic
     # via pydantic-core
     # via pyee
-tzdata==2024.1
-    # via pydantic
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests
 wrapt==1.16.0
     # via deprecated
     # via opentelemetry-instrumentation
 xmltodict==0.13.0
     # via apkutils2
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-metadata

--- a/src/compare.py
+++ b/src/compare.py
@@ -7,7 +7,7 @@ import logfire
 from pydantic import Field, BaseModel, ConfigDict, computed_field
 import PIL.Image as Image
 
-from src.types.image_models import ImageModel
+from .types.image_models import ImageModel
 
 
 class ImageComparison(BaseModel):

--- a/src/compare.py
+++ b/src/compare.py
@@ -6,8 +6,10 @@ import numpy as np
 import logfire
 from pydantic import Field, BaseModel, ConfigDict, computed_field
 import PIL.Image as Image
+from adbutils._device import AdbDevice
+from playwright.sync_api import Page
 
-from .types.image_models import ImageModel
+from .types import ImageModel, ShiftPosition
 
 
 class ImageComparison(BaseModel):
@@ -15,6 +17,7 @@ class ImageComparison(BaseModel):
 
     image_cfg: ImageModel = Field(..., description="The image configuration")
     screenshot: Image.Image | bytes = Field(..., description="The screenshot image")
+    device: Page | AdbDevice | ShiftPosition = Field(..., description="The device")
 
     @computed_field
     @property

--- a/src/compare.py
+++ b/src/compare.py
@@ -1,6 +1,6 @@
 import os
+from typing import Union
 
-# import datetime
 import cv2
 import numpy as np
 import logfire
@@ -16,8 +16,8 @@ class ImageComparison(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     image_cfg: ImageModel = Field(..., description="The image configuration")
-    screenshot: Image.Image | bytes = Field(..., description="The screenshot image")
-    device: Page | AdbDevice | ShiftPosition = Field(..., description="The device")
+    screenshot: Union[Image.Image, bytes] = Field(..., description="The screenshot image")
+    device: Union[Page, AdbDevice, ShiftPosition] = Field(..., description="The device")
 
     @computed_field
     @property
@@ -73,7 +73,8 @@ class ImageComparison(BaseModel):
             **self.image_cfg.model_dump(),
         )
 
-    def find(self) -> tuple[int | None, int | None]:
+    def find(self) -> tuple[int, int]:
+        button_center_x, button_center_y = 0, 0
         _, gray_screenshot = self.__screenshot_array
 
         result = cv2.matchTemplate(gray_screenshot, self.__button_image, cv2.TM_CCOEFF_NORMED)
@@ -95,5 +96,4 @@ class ImageComparison(BaseModel):
                 self.__draw_rectangle(
                     matched_image_position=matched_image_position, max_loc=max_loc, draw_black=True
                 )
-            return button_center_x, button_center_y
-        return None, None
+        return button_center_x, button_center_y

--- a/src/get_screen.py
+++ b/src/get_screen.py
@@ -64,6 +64,7 @@ class GetScreen(BaseModel):
                 "The current app is not the specified URL",
                 serial=device.serial,
                 app=running_app.package,
+                _exc_info=True,
             )
             raise Exception("The current app is not the specified URL")
         screenshot = device.screenshot()

--- a/src/get_screen.py
+++ b/src/get_screen.py
@@ -1,25 +1,26 @@
 import time
 
 from PIL import ImageGrab
+import logfire
 from adbutils import adb
 from pydantic import BaseModel
 import pygetwindow as gw
 from pygetwindow import Win32Window  # noqa: F401 for type hinting
 from playwright.sync_api import sync_playwright
 
-from src.types.output_models import DeviceOutput, ShiftPosition
+from .types.output_models import Screenshot, ShiftPosition
 
 
 class GetScreen(BaseModel):
     @classmethod
-    def from_exist_window(cls, window_title: str) -> DeviceOutput:
+    def from_exist_window(cls, window_title: str) -> Screenshot:
         """Capture a screenshot from an existing window.
 
         Args:
             window_title (str): The title of the window to capture.
 
         Returns:
-            DeviceOutput: An object containing the captured screenshot and the shift position.
+            Screenshot: An object containing the captured screenshot and the shift position.
 
         """
         window = gw.getWindowsWithTitle(window_title)[0]  # type: Win32Window
@@ -33,44 +34,51 @@ class GetScreen(BaseModel):
         screenshot = ImageGrab.grab(bbox=bbox)
         # For this method, there is always a shift position
         shift_position = ShiftPosition(shift_x=shift_x, shift_y=shift_y)
-
-        screenshot.save("screenshot.png")
-        return DeviceOutput(screenshot=screenshot, device=shift_position)
+        logfire.info("Screenshot taken", window_title=window_title)
+        return Screenshot(screenshot=screenshot, device=shift_position)
 
     @classmethod
-    def from_adb_device(cls, url: str, serial: str) -> DeviceOutput:
-        """Create a DeviceOutput object from an Android device using ADB.
+    def from_adb_device(cls, url: str, serial: str) -> Screenshot:
+        """Create a Screenshot object from an Android device using ADB.
 
         Args:
             url (str): The URL of the app to be opened on the device.
             serial (str): The serial number of the Android device.
 
         Returns:
-            DeviceOutput: An object containing the screenshot and device information.
+            Screenshot: An object containing the screenshot and device information.
 
         Raises:
             Exception: If the current app on the device is not the specified URL.
 
         """
+        # os.system(f".\\binaries\\adb.exe connect {serial}")
+        # commands = ["./binaries/adb.exe", "connect", serial]
+        # command_executor = CommandExecutor(commands=commands)
+        # command_executor.run()
         adb.connect(serial)
         device = adb.device(serial=serial)
-        current_app = device.app_current()
-        if current_app.package != url:
-            # device.app_start(url)
-            raise Exception(f"Please make sure you have opened the app: {url}")
-
+        running_app = device.app_current()
+        if running_app.package != url:
+            logfire.error(
+                "The current app is not the specified URL",
+                serial=device.serial,
+                app=running_app.package,
+            )
+            raise Exception("The current app is not the specified URL")
         screenshot = device.screenshot()
-        return DeviceOutput(screenshot=screenshot, device=device)
+        logfire.info("Screenshot taken", serial=device.serial, game=running_app.package)
+        return Screenshot(screenshot=screenshot, device=device)
 
     @classmethod
-    def from_remote_window(cls, url: str) -> DeviceOutput:
+    def from_remote_window(cls, url: str) -> Screenshot:
         """Create a screenshot of a remote window using Playwright.
 
         Args:
             url (str): The URL of the remote window.
 
         Returns:
-            DeviceOutput: An object containing the screenshot and the page.
+            Screenshot: An object containing the screenshot and the page.
 
         """
         with sync_playwright() as p:
@@ -90,4 +98,5 @@ class GetScreen(BaseModel):
             page = context.new_page()
             page.goto(url)
             screenshot = page.screenshot()
-            return DeviceOutput(screenshot=screenshot, device=page)
+            logfire.info("Screenshot taken", url=url)
+            return Screenshot(screenshot=screenshot, device=page)

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -1,0 +1,5 @@
+from .config import ConfigModel
+from .image_models import ImageModel
+from .output_models import ShiftPosition, Screenshot
+
+__all__ = ["ConfigModel", "ImageModel", "ShiftPosition", "Screenshot"]

--- a/src/types/config.py
+++ b/src/types/config.py
@@ -1,6 +1,6 @@
 from pydantic import Field, BaseModel
 
-from src.types.image_models import ImageModel
+from .image_models import ImageModel
 
 
 class ConfigModel(BaseModel):

--- a/src/types/output_models.py
+++ b/src/types/output_models.py
@@ -22,3 +22,15 @@ class Screenshot(BaseModel):
         elif isinstance(self.screenshot, Image.Image):
             self.screenshot.save(save_path)
         return save_path
+
+    def calibrate(self, button_center_x: int, button_center_y: int) -> tuple[int, int]:
+        # if the device is from a window process, we need to add shift_x, shift_y to the button_center_x, button_center_y
+        # since we do not know the exact position of the window.
+        if isinstance(self.device, Page):
+            pass  # place holder for future implementation
+        if isinstance(self.device, AdbDevice):
+            pass  # place holder for future implementation
+        if isinstance(self.device, ShiftPosition):
+            button_center_x = button_center_x + self.device.shift_x
+            button_center_y = button_center_y + self.device.shift_y
+        return button_center_x, button_center_y

--- a/src/types/output_models.py
+++ b/src/types/output_models.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from PIL import Image
 from pydantic import BaseModel, ConfigDict
 from adbutils._device import AdbDevice
@@ -11,8 +13,8 @@ class ShiftPosition(BaseModel):
 
 class Screenshot(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    screenshot: bytes | Image.Image
-    device: AdbDevice | Page | ShiftPosition
+    screenshot: Union[bytes, Image.Image]
+    device: Union[AdbDevice, Page, ShiftPosition]
 
     def save(self, save_path: str) -> str:
         save_path = f"{save_path}.png" if not save_path.endswith(".png") else save_path

--- a/src/types/output_models.py
+++ b/src/types/output_models.py
@@ -9,7 +9,7 @@ class ShiftPosition(BaseModel):
     shift_y: int
 
 
-class DeviceOutput(BaseModel):
+class Screenshot(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     screenshot: bytes | Image.Image
     device: AdbDevice | Page | ShiftPosition

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,4 @@
+from .command_utils import CommandExecutor
+from .get_serial import ADBDeviceManager, AppInfo
+
+__all__ = ["CommandExecutor", "ADBDeviceManager", "AppInfo"]

--- a/src/utils/command_utils.py
+++ b/src/utils/command_utils.py
@@ -12,8 +12,8 @@ class CommandExecutor(BaseModel):
         stdout = connection_result.stdout
         stderr = connection_result.stderr
         if stderr:
-            logfire.error("Error on executing", stderr=stderr)
-        logfire.info("Success on executing", stdout=stdout)
+            logfire.error("Error on executing", stderr=stderr, _exc_info=True)
+        logfire.info("Success on executing", stdout=stdout, _exc_info=True)
         return stdout, stderr
 
     def popen(self) -> tuple[str, str]:
@@ -22,6 +22,6 @@ class CommandExecutor(BaseModel):
         )
         stdout, stderr = connection_result_popen.communicate()
         if stderr:
-            logfire.error("Error on executing", stderr=stderr)
-        logfire.info("Success on executing", stdout=stdout)
+            logfire.error("Error on executing", stderr=stderr, _exc_info=True)
+        logfire.info("Success on executing", stdout=stdout, _exc_info=True)
         return stdout, stderr

--- a/src/utils/get_serial.py
+++ b/src/utils/get_serial.py
@@ -1,3 +1,4 @@
+import logfire
 from adbutils import adb
 from pydantic import Field, BaseModel, computed_field
 
@@ -13,23 +14,24 @@ class ADBDeviceManager(BaseModel):
 
     @computed_field
     @property
-    def avaliable_devices(self) -> list[int]:
+    def available_devices(self) -> list[int]:
         mumu_player = [16384, 16416]
         # ld_player = [5555, 5557]
-        avaliable_devices = [*mumu_player]
-        return avaliable_devices
+        available_devices = [*mumu_player]
+        return available_devices
 
     @computed_field
     @property
     def serials(self) -> list[str]:
-        for avaliable_device in self.avaliable_devices:
-            adb.connect(addr=f"{self.host}:{avaliable_device}", timeout=3.0)
+        for available_device in self.available_devices:
+            adb.connect(addr=f"{self.host}:{available_device}", timeout=3.0)
         devices = adb.device_list()
         serials = []
         for device in devices:
             if device.serial.startswith("emulator"):
                 continue
             serials.append(device.serial)
+        logfire.info("Available devices", serials=serials)
         return serials
 
     @computed_field
@@ -41,15 +43,16 @@ class ADBDeviceManager(BaseModel):
             running_app = device.app_current()
             running_details = AppInfo(**{"serial": serial, "package": running_app.package})
             running_apps.append(running_details)
+        logfire.info("Running apps", running_apps=running_apps)
         return running_apps
 
     def get_correct_serial(self) -> AppInfo:
-        apps = [
-            running_app for running_app in self.running_apps if running_app.package == self.target
-        ]
+        apps = [r_app for r_app in self.running_apps if r_app.package == self.target]
         if len(apps) > 1 or len(apps) == 0:
             raise Exception("Multiple or no devices found")
-        return apps[0]
+        app = next(iter(apps))
+        logfire.info("Correct device found", serial=app.serial, package=app.package)
+        return app
 
 
 if __name__ == "__main__":

--- a/src/utils/get_serial.py
+++ b/src/utils/get_serial.py
@@ -1,4 +1,3 @@
-import logfire
 from adbutils import adb
 from pydantic import Field, BaseModel, computed_field
 
@@ -31,7 +30,6 @@ class ADBDeviceManager(BaseModel):
             if device.serial.startswith("emulator"):
                 continue
             serials.append(device.serial)
-        logfire.info("Available devices", serials=serials)
         return serials
 
     @computed_field
@@ -43,7 +41,6 @@ class ADBDeviceManager(BaseModel):
             running_app = device.app_current()
             running_details = AppInfo(**{"serial": serial, "package": running_app.package})
             running_apps.append(running_details)
-        logfire.info("Running apps", running_apps=running_apps)
         return running_apps
 
     def get_correct_serial(self) -> AppInfo:
@@ -51,7 +48,6 @@ class ADBDeviceManager(BaseModel):
         if len(apps) > 1 or len(apps) == 0:
             raise Exception("Multiple or no devices found")
         app = next(iter(apps))
-        logfire.info("Correct device found", serial=app.serial, package=app.package)
         return app
 
 


### PR DESCRIPTION
## What does this PR do?

- Remove commented-out import statements for clarity
- Replace `DeviceOutput` class with `Screenshot` across all relevant files
- Replace `connect2adb` method with `get_screenshot`, updating its functionality to capture screenshots rather than connect to adb
- Change log configuration to disable sending logs to 'logfire' and remove the log token
- Update logging statements to include more contextual information such as window titles, URL, or serial numbers in screenshot methods
- Refactor `ImageComparison` methods to make them private and streamline image processing
- Streamline error handling and logging in methods dealing with remote and adb devices
- Add informative docstrings to methods that have changed to maintain code documentation
- Remove unused variables and commented-out code blocks to clean up the codebase
- Correct typographical errors in variable names (`avaliable` to `available`) and improve readability by modifying method names and parameters
