### PR TITLE
ci: refine CI build and deployment steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
+      - name: Get the version
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: metadata
+        uses: battila7/get-version-action@v2
+
+      - name: Setup Python
         uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.10'
@@ -47,17 +52,13 @@ jobs:
       - name: Move and Rename
         shell: pwsh
         run: |
-          Copy-Item -Path ./* -Destination ./dist/ -Recurse -Exclude dist, .git, .cache
-
-      - name: Get the version
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: metadata
-        uses: battila7/get-version-action@v2
+          Copy-Item -Path "./dist/*" -Destination "./" -Recurse -Force
+          Remove-Item -Recurse -Force build, dist, .venv, .cache -ErrorAction SilentlyContinue
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4.3.3
         with:
-          path: ./dist/*
+          path: ./*
           name: ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}
           if-no-files-found: ignore
           retention-days: 90
@@ -69,38 +70,68 @@ jobs:
         run: |
           Get-ChildItem -Path .
 
-  upload_artifacts:
-    name: Upload Release Assets
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: build_package
-    runs-on: ubuntu-latest
-    # container: catthehacker/ubuntu:act-20.04  # Uncomment it if you use it on Gitea
-
-    steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          name: ${{ github.event.repository.name }}
-
-      - name: Get the version
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: metadata
-        uses: battila7/get-version-action@v2
+          name: ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}
+          path: ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}
 
       - name: Check Files
+        shell: pwsh
         run: |
-          cd ..
-          zip -r ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}
-          ls -al
-          cp -R ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip ./${{ github.event.repository.name }}/
+          Compress-Archive -Path "${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}" -DestinationPath "${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip" -Force
+          ls -Force
+
+      # - name: Check Files
+      #   shell: pwsh
+      #   run: |
+      #     cd ..
+      #     Compress-Archive -Path "${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}" -DestinationPath "${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip" -Force
+      #     ls -Force
+      #     Copy-Item -Path "${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip" -Destination "./${{ github.event.repository.name }}/" -Force
 
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/v')
-        # continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
             ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip
+
+  # upload_artifacts:
+  #   name: Upload Release Assets
+  #   if: startsWith(github.ref, 'refs/tags/v')
+  #   needs: build_package
+  #   runs-on: ubuntu-latest
+  #   # container: catthehacker/ubuntu:act-20.04  # Uncomment it if you use it on Gitea
+
+  #   steps:
+  #     - name: Download Artifact
+  #       uses: actions/download-artifact@v4
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       with:
+  #         name: ${{ github.event.repository.name }}
+
+  #     - name: Get the version
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       id: metadata
+  #       uses: battila7/get-version-action@v2
+
+  #     - name: Check Files
+  #       run: |
+  #         cd ..
+  #         zip -r ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}
+  #         ls -al
+  #         cp -R ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip ./${{ github.event.repository.name }}/
+
+  #     - name: Upload Release Assets
+  #       uses: softprops/action-gh-release@v2
+  #       if: startsWith(github.ref, 'refs/tags/v')
+  #       # continue-on-error: true
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         files: |
+  #           ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip


### PR DESCRIPTION
## What does this PR do?

- Modify the workflow to include getting version data for tagged commits earlier in the build job
- Change file copy and delete commands to use specific folders and include error handling flags
- Update the artifact upload step to include entire directory instead of just the `dist` folder
- Simplify and clarify archival and upload process by changing commands and reorganizing steps under tagged commit conditions
