### PR TITLE
ci: refactor GitHub Actions and integrate Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.lock
+          pip install -r requirements.txt
           pip install pytest
           pip install pytest-cov
           pip install pytest-xdist
@@ -74,3 +74,16 @@ jobs:
         if: steps.check_tests.outputs.has_tests == 'true'
         run: |
           pytest -v
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./.github/reports/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          file: ./.github/reports/pytest.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

- Change pip installation from `requirements.lock` to `requirements.txt` in GitHub Actions workflow
- Add steps to upload coverage and test results to Codecov in GitHub Actions workflow